### PR TITLE
Normalizing Text: ffscraper.nlp.index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 install:
   - "pip install -r ffscraper/tests/requirements.txt"
-  - "python -m nltk.downloader -d $HOME/nltk_data"
+  - "python -m nltk.downloader stopwords -d $HOME/nltk_data"
 
 script:
   - coverage run ffscraper/tests/tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - coverage run ffscraper/tests/tests.py
 
 before_install:
+  export NLTK_DATA="$HOME/nltk_data"
   pip install codecov
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ python:
   - "3.6-dev"
   - "3.7-dev"
 
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/nltk_data
 
 install:
   - "pip install -r ffscraper/tests/requirements.txt"
+  - "python -c 'import nltk; nltk.download(\"stopwords\")'"
 
 script:
   - coverage run ffscraper/tests/tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 install:
   - "pip install -r ffscraper/tests/requirements.txt"
-  - "python -m nltk.downloader stopwords -d $HOME/nltk_data"
+  - "python -m nltk.downloader stopwords punkt -d $HOME/nltk_data"
 
 script:
   - coverage run ffscraper/tests/tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - coverage run ffscraper/tests/tests.py
 
 before_install:
-  export NLTK_DATA="$HOME/nltk_data"
+  export NLTK_DATA="$HOME/nltk_data";
   pip install codecov
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 install:
   - "pip install -r ffscraper/tests/requirements.txt"
-  - "python -c 'import nltk; nltk.download(\"stopwords\")'"
+  - "python -m nltk.downloader -d $HOME/nltk_data"
 
 script:
   - coverage run ffscraper/tests/tests.py

--- a/docs/source/ffscraper.nlp.rst
+++ b/docs/source/ffscraper.nlp.rst
@@ -1,0 +1,22 @@
+ffscraper\.nlp package
+================================
+
+Submodules
+----------
+
+ffscraper\.nlp\.index module
+--------------------------------------
+
+.. automodule:: ffscraper.nlp.index
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: ffscraper.nlp
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/ffscraper.rst
+++ b/docs/source/ffscraper.rst
@@ -8,6 +8,7 @@ Subpackages
 
     ffscraper.author
     ffscraper.fanfic
+    ffscraper.nlp
 
 Submodules
 ----------

--- a/ffscraper/__init__.py
+++ b/ffscraper/__init__.py
@@ -33,10 +33,11 @@ Example:
 __author__ = 'Alexander L. Hayes (@batflyer)'
 __copyright__ = 'Copyright (c) 2018 Alexander L. Hayes'
 __license__ = 'Apache License, Version 2.0'
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 __maintainer__ = __author__
 __email__ = 'alexander@batflyer.net'
 __status__ = 'Prototype'
 
 from . import fanfic
 from . import author
+from . import nlp

--- a/ffscraper/__main__.py
+++ b/ffscraper/__main__.py
@@ -26,7 +26,7 @@ from . import Utils
 __author__ = 'Alexander L. Hayes (@batflyer)'
 __copyright__ = 'Copyright (c) 2018 Alexander L. Hayes'
 __license__ = 'Apache License, Version 2.0'
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 __maintainer__ = __author__
 __email__ = 'alexander@batflyer.net'
 __status__ = 'Prototype'

--- a/ffscraper/nlp/__init__.py
+++ b/ffscraper/nlp/__init__.py
@@ -1,0 +1,5 @@
+"""
+Doc-string for nlp
+"""
+
+from . import index

--- a/ffscraper/nlp/__init__.py
+++ b/ffscraper/nlp/__init__.py
@@ -1,3 +1,18 @@
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 """
 Doc-string for nlp
 """

--- a/ffscraper/nlp/index.py
+++ b/ffscraper/nlp/index.py
@@ -33,19 +33,95 @@ story, profile, or a story review.
    words in their respective language (especially since Spanish, French,
    Indonesian, and a large handful of non-English languages are quite common).
 
+   ``ffscraper.nlp.index.normalize`` has a ``language`` parameter for
+   specifying the input language (based on ``nltk.stopwords`` corpora), but
+   these have not been thoroughly tested.
+
+**Basic example to highlight features:**
+
+.. code-block:: python
+
+                import ffscraper as ffs
+
+                basic_example = '''This is a short example. I want to build a
+                search engine for fanfiction.
+                '''
+
+                # Normalize our example with some NLP techniques, first by
+                # splitting our input into sentences, then splitting the
+                # sentences into lowercase words with punctuation removed.
+                sentences = ffs.nlp.index.normalize(basic_example)
+
+                print('Sentences after ffs.nlp.index.normalize:')
+                for sentence in sentences:
+                    print(sentence)
+
+.. code-block:: bash
+
+                ['short', 'exampl', '']
+                ['want', 'build', 'search', 'engin', 'fanfict', '']
+
+**Example with a larger input corpus:**
+
+.. code-block:: python
+
+                import ffscraper as ffs
+
+                declaration = '''When in the course of human events it
+                becomes necessary for one people to dissolve the political
+                bands which have connected them with another and to assume
+                among the powers of the earth, the separate and equal station
+                to which the Laws of Nature and of Nature's God entitle them,
+                a decent respect to the opinions of mankind requires that they
+                should declare the causes which impel them to the separation.
+
+                We hold these truths to be self-evident, that all men are
+                created equal, that they are endowed by their Creator with
+                certain unalienable Rights, that among these are Life,
+                Liberty and the pursuit of Happiness. That to secure these
+                rights, Governments are instituted among Men, deriving their
+                justpowers from the consent of the governed, That whenever
+                any Form of Government becomes destructive of these ends,
+                it is the Right of the People to alter or to abolish it, and
+                to institute new Government, laying its foundations on such
+                principles and organizing its powers in such form, as to them
+                shall seem most likely to effect their Safety and Happiness.
+                '''
+
+                # Normalize our input by splitting into sentences, and further
+                # splitting each sentence into lowercase words with stopwords
+                # and punctuation removed.
+                sentences = ffs.nlp.index.normalize(declaration)
+
+                for sentence in sentences:
+                    print(sentence)
+
+.. code-block:: bash
+
+                ['cours', 'human', 'event', 'becom', 'necessari', 'one',
+                'peopl', 'dissolv', 'polit', 'band', 'connect', 'anoth',
+                'assum', 'among', 'power', 'earth', '', 'separ', 'equal',
+                'station', 'law', 'natur', 'natur', 'god', 'entitl', '',
+                'decent', 'respect', 'opinion', 'mankind', 'requir', 'declar',
+                'caus', 'impel', 'separ', '']
+                ...[snipped]
 """
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from nltk import word_tokenize
 from nltk import sent_tokenize
 from nltk.corpus import stopwords
 from nltk.stem.porter import *
 
+import string
+
+_punctuation = string.punctuation
 _stemmer = PorterStemmer()
 _stopwords = stopwords.words('english')
 
-def __stemmer(word):
+def __stem(word):
     """
     .. versionadded:: 0.3.0
 
@@ -72,7 +148,7 @@ def __is_stopword(word):
     """
     return (word in _stopwords)
 
-def __remove_stopwords(list_of_words):
+def __remove_stopwords(list_of_words, language='english'):
     """
     .. versionadded:: 0.3.0
 
@@ -80,6 +156,9 @@ def __remove_stopwords(list_of_words):
 
     :param list_of_words: A list of words where each word is a string.
     :type list_of_words: str. list
+    :param language: A string representing the language the list of words
+                     is in [Default: 'english'].
+    :type language: str.
     :returns: A list of strings where stopwords have been removed.
     :rtype: list
 
@@ -104,7 +183,10 @@ def __remove_stopwords(list_of_words):
                     Stopwords Removed: ['writing', 'fanfiction']
 
     """
-    return [word for word in list_of_words if not __is_stopword(word)]
+    if language is not 'english':
+        return [word for word in list_of_words if word not in stopwords.words(language)]
+    else:
+        return [word for word in list_of_words if not __is_stopword(word)]
 
 def ngram(list_of_words, n=2):
     """
@@ -112,13 +194,57 @@ def ngram(list_of_words, n=2):
     """
     pass
 
+def __count_and_log(input):
+    pass
+
 def invert():
+    pass
+
+def normalize(string, language='english'):
     """
     .. versionadded:: 0.3.0
 
-    Create an inverted index from the input corpus.
+    Create an inverted index from the input.
+
+    :param string: A string, potentially with punctuation and newlines.
+    :type string: str.
+    :param language: Language of the input string.
+    :type language: str.
+
+    :returns: A generator. Each item corresponds to a sentence in the string,
+              each list consists of strings of lowercase words which have been
+              stopped and stemmed.
+    :rtype: generator
+
+    Order of operations:
+
+    1. Use ``nltk.sent_tokenize`` to split the input string into a list of
+       sentences.
+    2. Use ``nltk.word_tokenize`` on each sentence.
+    3. Convert words to lowercase and remove punctuation.
+    4. Remove stopwords from each of the sentences (dependent on the language).
     """
 
+    # Split the input string into sentences with nltk.sent_tokenize
+    sentences = sent_tokenize(string)
+
+    for sentence in sentences:
+
+        # 1. Tokenize the words.
+        words = word_tokenize(sentence)
+
+        # 2. Convert the words to lowercase and remove punctuation.
+        tokens = [word.lower().strip(_punctuation) for word in words]
+
+        # 3. Remove stopwords from the list of tokens.
+        stopped_tokens = __remove_stopwords(tokens, language=language)
+
+        # 4. Stem the stopped_tokens
+        stemmed_stopped_tokens = [__stem(word) for word in stopped_tokens]
+
+        # Yield results
+        yield stemmed_stopped_tokens
+
 if __name__ == '__main__':
-    print('No main method in ffscraper.nlp.deconstruct')
+    print('No main method in ffscraper.nlp.index')
     exit(1)

--- a/ffscraper/nlp/index.py
+++ b/ffscraper/nlp/index.py
@@ -244,7 +244,3 @@ def normalize(string, language='english'):
 
         # Yield results
         yield stemmed_stopped_tokens
-
-if __name__ == '__main__':
-    print('No main method in ffscraper.nlp.index')
-    exit(1)

--- a/ffscraper/nlp/index.py
+++ b/ffscraper/nlp/index.py
@@ -1,0 +1,124 @@
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
++---------------------+-----------------------------+
+|     **Name**        |       **Description**       |
++---------------------+-----------------------------+
+| ffscraper.nlp.index | A module for indexing text. |
++---------------------+-----------------------------+
+
+As text is read from FanFiction.Net, it would be useful to have some method
+for automatically analyzing, storing, and (inevitably) retrieving the data
+in a systematized way.
+
+This method helps to accomplish this by creating an inverted index from
+text passed into it, regardless of whether the text was originally from a
+story, profile, or a story review.
+
+.. note:: This currently assumes that the text passed into it is in English.
+   As this increases in complexity there should be a way to stem and index
+   words in their respective language (especially since Spanish, French,
+   Indonesian, and a large handful of non-English languages are quite common).
+
+"""
+
+from __future__ import print_function
+
+from nltk import word_tokenize
+from nltk import sent_tokenize
+from nltk.corpus import stopwords
+from nltk.stem.porter import *
+
+_stemmer = PorterStemmer()
+_stopwords = stopwords.words('english')
+
+def __stemmer(word):
+    """
+    .. versionadded:: 0.3.0
+
+    Method for stemming a set of words.
+
+    :param word: A word which should be stemmed.
+    :type word: str.
+    :returns: The porter stem of the input word.
+    :rtype: str.
+    """
+    return _stemmer.stem(word)
+
+def __is_stopword(word):
+    """
+    .. versionadded:: 0.3.0
+
+    Returns true if the word appears in the nltk stopwords corpus.
+
+    :param word: A query word which may or may not be a stopword.
+    :type word: str.
+    :returns: True or false, depending on whether the word appears in the nltk
+              stopwords corpus.
+    :rtype: bool
+    """
+    return (word in _stopwords)
+
+def __remove_stopwords(list_of_words):
+    """
+    .. versionadded:: 0.3.0
+
+    Remove stopwords from a list of words (in the form of strings).
+
+    :param list_of_words: A list of words where each word is a string.
+    :type list_of_words: str. list
+    :returns: A list of strings where stopwords have been removed.
+    :rtype: list
+
+    .. code-block:: python
+
+                    # This is 90% to show that it is possible,
+                    # try not to this unless it's absolutely necessary.
+
+                    from nltk import word_tokenize
+                    from ffscraper.nlp.index import __remove_stopwords
+
+                    sentence = 'i am writing fanfiction'
+                    low = word_tokenize(sentence)
+                    low_removed = __remove_stopwords(low)
+
+                    print('Original:', low)
+                    print('Stopwords Removed:', low_removed)
+
+    .. code-block:: bash
+
+                    Original: ['i', 'am', 'writing', 'fanfiction']
+                    Stopwords Removed: ['writing', 'fanfiction']
+
+    """
+    return [word for word in list_of_words if not __is_stopword(word)]
+
+def ngram(list_of_words, n=2):
+    """
+    Compute ngrams of a list of words. Returns bigrams by default.
+    """
+    pass
+
+def invert():
+    """
+    .. versionadded:: 0.3.0
+
+    Create an inverted index from the input corpus.
+    """
+
+if __name__ == '__main__':
+    print('No main method in ffscraper.nlp.deconstruct')
+    exit(1)

--- a/ffscraper/tests/ffscrapertests/test_nlp_index.py
+++ b/ffscraper/tests/ffscrapertests/test_nlp_index.py
@@ -1,0 +1,58 @@
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import print_function
+
+import sys
+import unittest
+
+sys.path.append('./')
+
+from ffscraper.nlp import index
+
+class IndexTest(unittest.TestCase):
+
+    def test_normalize_1(self):
+        # Basic test with uppercase letters and punctuation.
+
+        sentence_generator = index.normalize('Hello World!')
+        sentences = [sentence for sentence in sentence_generator]
+        self.assertEqual(sentences, [['hello', 'world', '']])
+
+    def test_normalize_2(self):
+        # Test with a variety of characters and punctuation over several lines.
+
+        sentence_generator = index.normalize('''In 19th-Century Russia we write
+        letters we write letters, we put down in writing what is happening in
+        our minds. Once it's on the paper we feel better we feel better, it's
+        like some kind of clarity when the letter's done and signed.
+        ''')
+
+        sentences = [sentence for sentence in sentence_generator]
+        expected = [[u'19th-centuri', 'russia', 'write', u'letter', 'write',
+        u'letter', '', 'put', u'write', u'happen', u'mind', ''],
+        ['paper', 'feel', 'better', 'feel', 'better', '', u"it'", 'like',
+        'kind', u'clariti', 'letter', 'done', u'sign', '']]
+
+        self.assertEqual(sentences, expected)
+
+    def test_normalize_3(self):
+        # Test with possibly unconventional input: an empty string.
+
+        sentence_generator = index.normalize('')
+        sentences = [sentence for sentence in sentence_generator]
+        expected = []
+
+        self.assertEqual(sentences, expected)

--- a/ffscraper/tests/ffscrapertests/test_nlp_index.py
+++ b/ffscraper/tests/ffscrapertests/test_nlp_index.py
@@ -43,8 +43,8 @@ class IndexTest(unittest.TestCase):
         sentences = [sentence for sentence in sentence_generator]
         expected = [[u'19th-centuri', 'russia', 'write', u'letter', 'write',
         u'letter', '', 'put', u'write', u'happen', u'mind', ''],
-        ['paper', 'feel', 'better', 'feel', 'better', '', u"it'", 'like',
-        'kind', u'clariti', 'letter', 'done', u'sign', '']]
+        ['paper', 'feel', 'better', 'feel', 'better', '', 'like', 'kind',
+        u'clariti', 'letter', 'done', u'sign', '']]
 
         self.assertEqual(sentences, expected)
 

--- a/ffscraper/tests/requirements.txt
+++ b/ffscraper/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-cov
 unittest2
 bs4
 requests
+nltk


### PR DESCRIPTION
`ffscraper.nlp.index` has a handful of methods for normalizing and indexing text. This is mostly built out of methods from nltk (stopwords, the Porter Stemmer, `sent_tokenize`, and `word_tokenize`).

Furthermore, this provides test cases and adjustments to the `.travis.yml` for building and caching with nltk corpora and packages.