### PR TITLE
fanfic scraping and nlp tools

### DIFF
--- a/ffscraper/fanfic/story.py
+++ b/ffscraper/fanfic/story.py
@@ -46,6 +46,7 @@ def _category_and_fandom(soup):
 
     :returns: Tuple where the first item is the category and the second item is
               the fandom.
+    :rtype: tuple.
 
     .. code-block:: python
 
@@ -66,6 +67,36 @@ def _category_and_fandom(soup):
 
     c_f = soup.find('div', {'id': 'pre_story_links'}).find_all('a', href=True)
     return c_f[0].text, c_f[1].text
+
+def _title(soup):
+    """
+    .. versionadded:: 0.3.0
+
+    Returns the fanfic's title from the soup.
+
+    :param soup: Soup containing a page from FanFiction.Net
+    :type soup: bs4.BeautifulSoup class
+
+    :returns: The title of the fanfic as a string.
+    :rtype: str.
+
+    .. code-block:: python
+
+                    from ffscraper.fanfic.story import _title
+                    from bs4 import BeautifulSoup as bs
+                    import requests
+
+                    r = requests.get('https://www.fanfiction.net/s/123')
+                    html = r.text
+                    soup = bs(html, 'html.parser')
+
+                    print(_title(soup))
+
+    .. code-block:: bash
+
+                    'There Once was a Man from Gilneas'
+    """
+    return soup.find('b', {'class': 'xcontrast_txt'}).text
 
 def scraper(storyid, rate_limit=3):
     """
@@ -115,7 +146,8 @@ def scraper(storyid, rate_limit=3):
     metadata = [s.strip() for s in metadata.split('-')]
 
     # Title from <b class='xcontrast_txt'>...</b>
-    title = soup.find('b', {'class': 'xcontrast_txt'}).text
+    title = _title(soup)
+    #title = soup.find('b', {'class': 'xcontrast_txt'}).text
 
     # Abstract and story are identified by <div class='xcontrast_txt'>...</div>
     abstract_and_story = soup.find_all('div', {'class': 'xcontrast_txt'})

--- a/ffscraper/fanfic/story.py
+++ b/ffscraper/fanfic/story.py
@@ -30,6 +30,43 @@ from bs4 import BeautifulSoup as bs
 import requests
 import time
 
+def _category_and_fandom(soup):
+    """
+    .. versionadded:: 0.3.0
+
+    Returns the FanFiction category and fandom from the soup.
+
+    * Category is one of nine possible categories from ``['Anime/Manga', 'Books',
+      'Cartoons', 'Comics', 'Games', 'Misc', 'Movies', 'Plays/Musicals', 'TV']``
+    * Fandom is the specific sub-category, whereas category may be
+     ``Plays/Musicals``, the fandom could be ``RENT``, ``Wicked``, etc.
+
+    :param soup: Soup containing a page from FanFiction.Net
+    :type soup: bs4.BeautifulSoup class
+
+    :returns: Tuple where the first item is the category and the second item is
+              the fandom.
+
+    .. code-block:: python
+
+                    from ffscraper.fanfic.story import __category_and_fandom
+                    from bs4 import BeautifulSoup as bs
+                    import requests
+
+                    r = requests.get('https://www.fanfiction.net/s/123')
+                    html = r.text
+                    soup = bs(html, 'html.parser')
+
+                    print(_category_and_fandom(soup))
+
+    .. code-block:: bash
+
+                    ('Plays/Musicals', 'Wicked')
+    """
+
+    c_f = soup.find('div', {'id': 'pre_story_links'}).find_all('a', href=True)
+    return c_f[0].text, c_f[1].text
+
 def scraper(storyid, rate_limit=3):
     """
     .. versionadded:: 0.1.0
@@ -46,11 +83,18 @@ def scraper(storyid, rate_limit=3):
 
     Example (*the output presented here has been altered*):
 
-    >>> from ffscraper.fanfic import story
-    >>> story123 = story.scraper('123')
-    >>> print(story123)
-    {'genre': 'Western', 'sid': '123', 'Reviewers': ['12', '24'],
-    'rating': 'Rated: Fiction  K', 'aid': "241"}
+    .. code-block:: python
+
+                    from ffscraper.fanfic import story
+
+                    # story.scraper is a handy interface for all of these.
+                    story123 = story.scraper('123')
+                    print(story123)
+
+    .. code-block:: bash
+
+                    {'genre': 'Western', 'sid': '123', 'Reviewers':
+                    ['12', '24'], 'rating': 'Rated: Fiction  K', 'aid': "241"}
     """
 
     # Rate limit
@@ -62,9 +106,7 @@ def scraper(storyid, rate_limit=3):
     soup = bs(html, 'html.parser')
 
     # Get the category and fandom information.
-    c_f = soup.find('div', {'id': 'pre_story_links'}).find_all('a', href=True)
-    category = c_f[0].text
-    fandom = c_f[1].text
+    category, fandom = _category_and_fandom(soup)
 
     # Get the metadata describing properties of the story.
     # This should contain the metadata line (e.g. rating, genre, words, etc.)
@@ -122,8 +164,3 @@ def scraper(storyid, rate_limit=3):
 
     #print(soup.prettify())
     return story
-
-if __name__ == '__main__':
-
-    raise(Exception('No main class in story.py'))
-    exit(1)

--- a/ffscraper/tests/ffscrapertests/test_fanfic_story.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_story.py
@@ -25,7 +25,7 @@ import unittest
 sys.path.append('./')
 from ffscraper.fanfic import story
 
-class StoryTest(unittest.TestCase):
+class CategoryAndFandomTest(unittest.TestCase):
 
     def test_category_and_fandom_1(self):
         # 1: Check Plays/Musicals category and fandom.
@@ -76,3 +76,22 @@ class StoryTest(unittest.TestCase):
         self.assertEqual(fandom, u'Attack on Titan/進撃の巨人')
 
         self.assertTrue(True)
+
+class TitleTest(unittest.TestCase):
+
+    def test_title_1(self):
+        # 1. Test generic input.
+
+        soup = bs("<b class='xcontrast_txt'>Hello World</b>", 'html.parser')
+        self.assertEqual(story._title(soup), 'Hello World')
+
+    def test_title_2(self):
+        # 2. Test with unicode characters.
+        soup = bs(u"<b class='xcontrast_txt'>Attack on Titan/進撃の巨人</b>",
+        'html.parser')
+        self.assertEqual(story._title(soup), u'Attack on Titan/進撃の巨人')
+
+    def test_title_3(self):
+        # 3. Test with potentially strange input: no title.
+        soup = bs("<b class='xcontrast_txt'></b>", 'html.parser')
+        self.assertEqual(story._title(soup), '')

--- a/ffscraper/tests/ffscrapertests/test_fanfic_story.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_story.py
@@ -95,3 +95,34 @@ class TitleTest(unittest.TestCase):
         # 3. Test with potentially strange input: no title.
         soup = bs("<b class='xcontrast_txt'></b>", 'html.parser')
         self.assertEqual(story._title(soup), '')
+
+class TimestampsTest(unittest.TestCase):
+
+    def test_timestamp_1(self):
+        # 1. Test case where Published and Updated are the same.
+
+        soup = bs(u"""<span class='xgray xcontrast_txt'>Rated:
+        <a class='xcontrast_txt' href='https://www.fictionratings.com/'
+        target='rating'>Fiction  K+</a> - French  - Words: 2,100 - Reviews:
+        <a href='/r/15/'>103</a> - Favs: 3 - Follows: 5 - Published:
+        <span data-xutime='1123840800'>8/12/2005</span> - id: 15 </span>""",
+        'html.parser')
+
+        published, updated = story._timestamps(soup)
+        self.assertEqual(published, '1123840800')
+        self.assertEqual(updated, '1123840800')
+
+    def test_timestamp_2(self):
+        # 2. Test case where Published and Updated are different.
+
+        soup = bs(u"""<span class='xgray xcontrast_txt'>Rated:
+        <a class='xcontrast_txt' href='https://www.fictionratings.com/'
+        target='rating'>Fiction  T</a> - English - Chapters: 6   -
+        Words: 6,198 - Reviews: <a href='/r/200/'>19</a> -
+        Updated: <span data-xutime='183818181'>5/5/2000</span> -
+        Published: <span data-xutime='12392811'>5/5/1999</span> -
+        id: 200 </span>""", 'html.parser')
+
+        published, updated = story._timestamps(soup)
+        self.assertEqual(published, '12392811')
+        self.assertEqual(updated, '183818181')

--- a/ffscraper/tests/ffscrapertests/test_fanfic_story.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_story.py
@@ -1,0 +1,78 @@
+
+# -*- coding: utf-8 -*-
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import print_function
+
+from bs4 import BeautifulSoup as bs
+import sys
+import unittest
+
+# This set of tests is interested in ffscraper.fanfic.story
+sys.path.append('./')
+from ffscraper.fanfic import story
+
+class StoryTest(unittest.TestCase):
+
+    def test_category_and_fandom_1(self):
+        # 1: Check Plays/Musicals category and fandom.
+
+        soup = bs("""<div style='margin-bottom: 10px' class='lc-wrapper'
+        id=pre_story_links><span class=lc-left><a class=xcontrast_txt
+        href='/play/'>Plays/Musicals</a>
+        <span class='xcontrast_txt icon-chevron-right xicon-section-arrow'>
+        </span><a class=xcontrast_txt href="/play/RENT/">RENT</a></span></div>
+        """, 'html.parser')
+
+        category, fandom = story._category_and_fandom(soup)
+
+        self.assertEqual(category, 'Plays/Musicals')
+        self.assertEqual(fandom, 'RENT')
+
+    def test_category_and_fandom_2(self):
+        # 2. Check an Anime/Manga category and fandom.
+
+        soup = bs("""<div style='margin-bottom: 10px' class='lc-wrapper'
+        id=pre_story_links><span class=lc-left>
+        <a class=xcontrast_txt href='/anime/'>Anime/Manga</a>
+        <span class='xcontrast_txt icon-chevron-right xicon-section-arrow'>
+        </span><a class=xcontrast_txt href="/anime/Inuyasha/">Inuyasha</a>
+        </span></div>""", 'html.parser')
+
+        category, fandom = story._category_and_fandom(soup)
+
+        self.assertEqual(category, 'Anime/Manga')
+        self.assertEqual(fandom, 'Inuyasha')
+
+    def test_category_and_fandom_3(self):
+        # 3. Check an Anime/Manga fandom with less-frequent characters.
+        #    Encoding issues may arise in Python 2.7 with ascii vs. unicode.
+        #    In these cases it should be noted that unicode is not default,
+        #    so u'' is specified for the strings.
+
+        soup = bs(u"""<div style='margin-bottom: 10px' class='lc-wrapper'
+        id=pre_story_links><span class=lc-left>
+        <a class=xcontrast_txt href='/anime/'>Anime/Manga</a>
+        <span class='xcontrast_txt icon-chevron-right xicon-section-arrow'>
+        </span><a class=xcontrast_txt href="/anime/Attack-on-Titan-%E9%80%B2%E6%92%83%E3%81%AE%E5%B7%A8%E4%BA%BA/">Attack on Titan/進撃の巨人</a>
+        </span></div>""", 'html.parser')
+
+        category, fandom = story._category_and_fandom(soup)
+
+        self.assertEqual(category, 'Anime/Manga')
+        self.assertEqual(fandom, u'Attack on Titan/進撃の巨人')
+
+        self.assertTrue(True)

--- a/ffscraper/tests/ffscrapertests/test_nlp_index.py
+++ b/ffscraper/tests/ffscrapertests/test_nlp_index.py
@@ -17,6 +17,8 @@
 
 from __future__ import print_function
 
+from collections import Counter
+
 import sys
 import unittest
 
@@ -79,3 +81,48 @@ class IndexTest(unittest.TestCase):
         u'', u'plumerai', u''], [u'plumerai', u'tête', u'']]
 
         self.assertEqual(sentences, expected)
+
+class WordcountTest(unittest.TestCase):
+
+    def test_wordcount_1(self):
+        # 1. The example supplied in the documentation.
+
+        doc = index.normalize(u'''O Captain! my Captain! our fearful trip
+                is done, The ship has weather'd every rack, the prize we
+                sought is won, The port is near, the bells I hear, the
+                people all exulting, While follow eyes the steady keel,
+                the vessel grim and daring; But O heart! heart! heart!
+                O the bleeding drops of red, Where on the deck my Captain
+                lies, Fallen cold and dead.''', language='english')
+
+        expected = Counter({'captain': 3, 'heart': 3, 'fear': 1, 'trip': 1,
+                'done': 1, 'ship': 1, 'weather': 1, 'everi': 1, 'rack': 1,
+                'prize': 1, 'sought': 1, 'port': 1, 'near': 1, 'bell': 1,
+                'hear': 1, 'peopl': 1, 'exult': 1, 'follow': 1, 'eye': 1,
+                'steadi': 1, 'keel': 1, 'vessel': 1, 'grim': 1, 'dare': 1,
+                'bleed': 1, 'drop': 1, 'red': 1, 'deck': 1, 'lie': 1,
+                'fallen': 1, 'cold': 1, 'dead': 1})
+
+        self.assertEqual(index.wordcount(doc), expected)
+
+    def test_wordcount_2(self):
+        # 2. A short example where we can easily count the words.
+
+        doc = index.normalize(u'Hello hello hello world goodbye')
+        expected = Counter({'hello': 3, 'world': 1, 'goodby': 1})
+        self.assertEqual(index.wordcount(doc), expected)
+
+    def test_wordcount_3(self):
+        # 3. Possibly strange input: where we normalize an empty string.
+
+        doc = index.normalize('')
+        expected = Counter({})
+        self.assertEqual(index.wordcount(doc), expected)
+
+    def test_wordcount_4(self):
+        # 4. Examples so far have used the index.normalize function, this
+        #    test uses lists of lists of strings.
+
+        doc = [['a', 'b', 'c'], ['a', 'b', 'd'], ['a', 'a', 'a']]
+        expected = Counter({'a': 5, 'b': 2, 'c': 1, 'd': 1})
+        self.assertEqual(index.wordcount(doc), expected)

--- a/ffscraper/tests/ffscrapertests/test_nlp_index.py
+++ b/ffscraper/tests/ffscrapertests/test_nlp_index.py
@@ -1,4 +1,6 @@
 
+# -*- coding: utf-8 -*-
+
 #   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,14 +29,14 @@ class IndexTest(unittest.TestCase):
     def test_normalize_1(self):
         # Basic test with uppercase letters and punctuation.
 
-        sentence_generator = index.normalize('Hello World!')
+        sentence_generator = index.normalize(u'Hello World!')
         sentences = [sentence for sentence in sentence_generator]
         self.assertEqual(sentences, [['hello', 'world', '']])
 
     def test_normalize_2(self):
         # Test with a variety of characters and punctuation over several lines.
 
-        sentence_generator = index.normalize('''In 19th-Century Russia we write
+        sentence_generator = index.normalize(u'''In 19th-Century Russia we write
         letters we write letters, we put down in writing what is happening in
         our minds. Once it's on the paper we feel better we feel better, it's
         like some kind of clarity when the letter's done and signed.
@@ -51,8 +53,29 @@ class IndexTest(unittest.TestCase):
     def test_normalize_3(self):
         # Test with possibly unconventional input: an empty string.
 
-        sentence_generator = index.normalize('')
+        sentence_generator = index.normalize('', language='english')
         sentences = [sentence for sentence in sentence_generator]
         expected = []
+
+        self.assertEqual(sentences, expected)
+
+    def test_normalize_4(self):
+        # Test with possibly unconventional input: an empty string in French.
+
+        sentence_generator = index.normalize('', language='french')
+        sentences = [sentence for sentence in sentence_generator]
+        expected = []
+
+        self.assertEqual(sentences, expected)
+
+    def test_normalize_5(self):
+        # Test with French instead of English.
+
+        sentence_generator = index.normalize(u'''Alouette, gentille alouette,
+        Alouette, je te plumerai. Je te plumerai la tête.''', language='french')
+
+        sentences = [sentence for sentence in sentence_generator]
+        expected = [[u'alouett', u'', u'gentil', u'alouett', u'', u'alouett',
+        u'', u'plumerai', u''], [u'plumerai', u'tête', u'']]
 
         self.assertEqual(sentences, expected)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
 
         # Supported Python Versions.
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ],
 
     keywords='fanfiction scraping search',


### PR DESCRIPTION
### This pull request makes the following changes:

* `ffscraper.fanfic.story.py` had several parts change into functions (`_title`, `_timestamps`, and `_category_and_fandom`) in order to allow individual pieces to be tested more easily. This gets around the potential problem of testing against pages while they are being hosted on FanFiction.Net, problematic since we would have to cache content in order to test against it.
* `ffscraper.nlp.index` has fairly complete portions for creating bag-of-words (`index.wordcount`), normalizing (`index.normalize`), and creating an inverted index (`index.invert`).

### New and Updated Test cases:

* `test_fanfic_story.py`: tests for the three functions mentioned above.
* `test_nlp_index.py`: more tests for `normalize` and `wordcount`, the former now has a test case in French.

### General comments:

`index.invert` may still change before the `0.3.0` release in order to better accommodate pickling, merging dictionaries, or inserting entries into a database.

### Minor changes:

* `setup.py` now lists specific Python versions (3.4, 3.5, and 3.6) instead of defaulting to 3. These versions which are tested in each build and are therefore the ones being supported.