### PR TITLE
__main__ rewrite, logging, and relative likes for fandom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 .mypy_cache/
 facts.txt
 cytoscape.txt
+sids.txt

--- a/ffscraper/__main__.py
+++ b/ffscraper/__main__.py
@@ -124,17 +124,8 @@ elif args.file:
             current_story = story.scraper(sid)
             logger.info('Finished scraping sid: ' + sid)
         except Exception:
-
-            # If errors are encountered, alert the user and dump the problematic sid.
+            # If errors are encountered, log an exception.
             logger.error('Problem while scraping fanfiction.net/s/' + sid, exc_info=True)
-            '''
-            error_file = 'UNKNOWN.txt'
-
-            print('\nEncountered an error while scraping {0}.'.format(sid))
-            print('Adding sid to file: {0}'.format(error_file))
-            with open(error_file, 'a') as f:
-                f.write(sid + '\n')
-            '''
             continue
 
         predicates = []
@@ -164,3 +155,7 @@ elif args.file:
         with open(args.Cout, 'a') as f:
             for p in schema:
                 f.write(p + '\n')
+
+# Shut down the logger and exit with no errors.
+logging.shutdown()
+exit(0)

--- a/ffscraper/__main__.py
+++ b/ffscraper/__main__.py
@@ -18,11 +18,13 @@ from __future__ import division
 
 import argparse
 import copy
+import logging
 
 from .fanfic import story
 from .fanfic import review
 from . import Utils
 
+# <Metadata>
 __author__ = 'Alexander L. Hayes (@batflyer)'
 __copyright__ = 'Copyright (c) 2018 Alexander L. Hayes'
 __license__ = 'Apache License, Version 2.0'
@@ -30,7 +32,22 @@ __version__ = '0.3.0-prerelease'
 __maintainer__ = __author__
 __email__ = 'alexander@batflyer.net'
 __status__ = 'Prototype'
+# </Metadata>
 
+# <Logging>
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+log_handler = logging.FileHandler('main_log.log')
+log_handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+log_handler.setFormatter(formatter)
+
+logger.addHandler(log_handler)
+logger.info('Started logger.')
+# </Logging>
+
+# <Argument Parser>
 parser = argparse.ArgumentParser(
     description='''Scraper for FanFiction.Net.''',
     epilog='''Copyright (c) 2018 Alexander L. Hayes. Distributed under the
@@ -56,6 +73,7 @@ parser.add_argument('-co', '--Cout', type=str, default='cytoscape.txt',
     help='Set output file for cytoscape network file.')
 parser.add_argument('-o', '--output', type=str, default='facts.txt',
     help='Set output file the information scraped.')
+# </Argument Parser>
 
 args = parser.parse_args()
 
@@ -102,16 +120,21 @@ elif args.file:
         counter += 1
 
         try:
+            logger.info('Started scraping sid: ' + sid)
             current_story = story.scraper(sid)
-        except:
+            logger.info('Finished scraping sid: ' + sid)
+        except Exception:
 
             # If errors are encountered, alert the user and dump the problematic sid.
+            logger.error('Problem while scraping fanfiction.net/s/' + sid, exc_info=True)
+            '''
             error_file = 'UNKNOWN.txt'
 
             print('\nEncountered an error while scraping {0}.'.format(sid))
             print('Adding sid to file: {0}'.format(error_file))
             with open(error_file, 'a') as f:
                 f.write(sid + '\n')
+            '''
             continue
 
         predicates = []

--- a/ffscraper/__main__.py
+++ b/ffscraper/__main__.py
@@ -16,9 +16,17 @@
 from __future__ import print_function
 from __future__ import division
 
+# Python Standard Library Modules
 import argparse
 import copy
 import logging
+import sys
+
+# Python 2/3 Compatability for Pickling.
+if sys.version_info < (3,0,0):
+    import cPickle as pickle
+else:
+    import pickle
 
 from .fanfic import story
 from .fanfic import review
@@ -77,6 +85,12 @@ parser.add_argument('-o', '--output', type=str, default='facts.txt',
 
 args = parser.parse_args()
 
+def schemaString(a1, a2, a3):
+    """
+    Return the the arguments as a string for use in Cytoscape.
+    """
+    return a1 + ' ' + a2 + ' ' + a3
+
 if args.version:
     print(__version__)
     exit(0)
@@ -85,11 +99,17 @@ if args.sid:
     # Scrape the contents of a single file from FanFiction.Net
     current_story = story.scraper(args.sid)
 
+    # Create predicates for BoostSRL.
     predicates = []
-    predicates.append(Utils.PredicateLogicBuilder('author', current_story['aid'], current_story['sid']))
-    predicates.append(Utils.PredicateLogicBuilder('rating', current_story['sid'], current_story['rating']))
-    predicates.append(Utils.PredicateLogicBuilder('genre', current_story['sid'], current_story['genre']))
-
+    predicates.append(Utils.PredicateLogicBuilder('author',
+                                                  current_story['aid'],
+                                                  current_story['sid']))
+    predicates.append(Utils.PredicateLogicBuilder('rating',
+                                                  current_story['sid'],
+                                                  current_story['rating']))
+    predicates.append(Utils.PredicateLogicBuilder('genre',
+                                                  current_story['sid'],
+                                                  current_story['genre']))
     for p in predicates:
         print(p)
 
@@ -105,57 +125,85 @@ elif args.review:
 elif args.file:
     # Import the sids from the file and scrape each of them.
 
+    # Initialize the sids as a stack
     sids = Utils.ImportStoryIDs(args.file)
-    # Initialize a remaining_sids list as a copy of sids
-    remaining_sids = copy.copy(sids)
 
-    # Values for the progress bar.
+    # Initialize the number_of_sids to avoid recalculation and a counter from 0
     number_of_sids = len(sids)
     counter = 0
 
-    for sid in sids:
+    # Initialize a set of people.
+    people = set()
+
+    while sids:
+
+        # Pop the current sid off the stack
+        sid = sids.pop()
 
         # Helpful progress bar
-        Utils.progress(counter, number_of_sids, status='Currently on: {0}...'.format(sid))
-        counter += 1
+        Utils.progress(counter, number_of_sids,
+                       status='Scraping: {0}...'.format(sid))
 
+        # Try scraping the story. If it fails, log and move on.
         try:
             logger.info('Started scraping sid: ' + sid)
-            current_story = story.scraper(sid)
+            current_story = story.scraper(sid, rate_limit=1)
             logger.info('Finished scraping sid: ' + sid)
         except Exception:
-            # If errors are encountered, log an exception.
-            logger.error('Problem while scraping fanfiction.net/s/' + sid, exc_info=True)
+            # If errors occur, log the exception.
+            logger.error('fanfiction.net/s/' + sid, exc_info=True)
             continue
 
+        # Add the author of the current story to the set of people.
+        people.add(current_story['aid'])
+
+        # Initialize predicates for BoostSRL and schema for Cytoscape.
         predicates = []
-        # schema will be used with cytoscape
         schema = []
 
-        schema.append('user' + current_story['aid'] + ' wrote story' + current_story['sid'])
+        # Create a schema list for Cytoscape.
+        schema.append(schemaString('user' + current_story['aid'],
+                                   'wrote',
+                                   'story' + current_story['sid']))
 
-        predicates.append(Utils.PredicateLogicBuilder('author', current_story['aid'], current_story['sid']))
-        predicates.append(Utils.PredicateLogicBuilder('rating', current_story['sid'], current_story['rating']))
-        predicates.append(Utils.PredicateLogicBuilder('genre', current_story['sid'], current_story['genre']))
+        # Create predicates for BoostSRL.
+        predicates.append(Utils.PredicateLogicBuilder('author',
+                                                      current_story['aid'],
+                                                      current_story['sid']))
+        predicates.append(Utils.PredicateLogicBuilder('rating',
+                                                      current_story['sid'],
+                                                      current_story['rating']))
+        predicates.append(Utils.PredicateLogicBuilder('genre',
+                                                      current_story['sid'],
+                                                      current_story['genre']))
 
         if current_story.get('Reviewers'):
-            reviewers = current_story['Reviewers']
 
-            for reviewer in reviewers:
-                predicates.append(Utils.PredicateLogicBuilder('reviewed', reviewer, current_story['sid']))
-                schema.append('user' + reviewer + ' reviewed story' + current_story['sid'])
+            # Add reviewers to the set of people.
+            people = people.union(set(current_story['Reviewers']))
 
-        # Remove the current sid from the list of remaining_sids
-        remaining_sids.remove(sid)
+            # Create associated predicates and Cytoscape schemas.
+            for reviewer in current_story['Reviewers']:
+                predicates.append(
+                    Utils.PredicateLogicBuilder('reviewed',
+                                                reviewer,
+                                                current_story['sid'])
+                    )
+                schema.append(schemaString('user' + reviewer,
+                                           'reviewed',
+                                           'story' + current_story['sid']))
 
         with open(args.output, 'a') as f:
             for p in predicates:
                 f.write(p + '\n')
-
         with open(args.Cout, 'a') as f:
             for p in schema:
                 f.write(p + '\n')
 
+        # increment our counter
+        counter += 1
+
 # Shut down the logger and exit with no errors.
+logger.info('Reached bottom of file, shutting down logger.')
 logging.shutdown()
 exit(0)

--- a/ffscraper/author/profile.py
+++ b/ffscraper/author/profile.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 
 from __future__ import print_function
+from __future__ import division
 
 from bs4 import BeautifulSoup as bs
 
@@ -77,6 +78,47 @@ def _metadata_fandom(soup_tag):
     """
     return soup_tag['data-category']
 
+def _relative_likes(favorite_stories, inverted_favorites, fandom):
+    """
+    .. versionadded:: 0.3.0
+
+    Returns how many stories a user likes in a fandom over all fandoms
+    that they like.
+
+    :param favorite_stories: List of story-ids liked by a user.
+    :type favorite_stories: list.
+    :param inverted_favorites: Dictionary mapping fandoms to the story-ids in
+                               that fandom liked by a user.
+    :type inverted_favorites: dict.
+    :param fandom: String representing the fandom.
+    :type fandom: str.
+
+    :returns: Approximate calculation for how much a user likes a fandom.
+    :rtype: float
+
+    .. note:: This is far from a perfect calculation. This should really take
+              a few more metrics into account, such as the number of stories
+              a person has written for a particular fandom, the sentiment of
+              the reviews they left over all stories they reviewed for a
+              fandom, etc.
+    """
+
+    # Calculate roughly how much this person likes this fandom.
+    number_of_favorites = len(favorite_stories)
+
+    # If the user likes no fanfics
+    if not number_of_favorites:
+        return 0.0
+
+    # If they like at least one story from the fandom, get the number.
+    if inverted_favorites.get(fandom):
+        favorites_for_fandom = len(inverted_favorites[fandom])
+    else:
+        return 0.0
+
+    # If they like at least one fanfic and one from this fandom, return score.
+    return favorites_for_fandom / number_of_favorites
+
 def scraper(uid, rate_limit=3):
     """
     Scrapes the data from a user's profile on FanFiction.Net.
@@ -114,17 +156,6 @@ def scraper(uid, rate_limit=3):
     html = r.text
     soup = bs(html, 'html.parser')
 
-    #favorite_stories = soup.find_all('div', {'class': 'z-list favstories'})
-    favorite_stories, inverted_favorites = _favorite_stories(soup)
-
-    for fandom in inverted_favorites.keys():
-        print(fandom, len(inverted_favorites[fandom]))
-
-    #print(favorite_stories[0])
-    print(len(favorite_stories))
-
-
-if __name__ == '__main__':
-    # This behavior is for testing, will likely be deprecated or changed later.
-
-    exit(0)
+    #soup.find_all('div', {'class': 'z-list favstories'})
+    #Returns a tuple of (favorite_stories, inverted_favorites)
+    return _favorite_stories(soup)

--- a/ffscraper/fanfic/story.py
+++ b/ffscraper/fanfic/story.py
@@ -227,7 +227,7 @@ def scraper(storyid, rate_limit=3):
             if 'Reviews' in m:
 
                 num_of_reviews = int(m.split()[1].replace(',',''))
-                users = review.ReviewIDScraper(storyid, num_of_reviews)
+                users = review.ReviewIDScraper(storyid, num_of_reviews, rate_limit=rate_limit)
                 story['Reviewers'] = users
 
         #print(metadata)

--- a/ffscraper/tests/ffscrapertests/test_author_profile.py
+++ b/ffscraper/tests/ffscrapertests/test_author_profile.py
@@ -1,0 +1,79 @@
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+from __future__ import print_function
+
+from bs4 import BeautifulSoup as bs
+import sys
+import unittest
+
+# This set of tests is interested in ffscraper.fanfic.author
+sys.path.append('./')
+from ffscraper.author import profile
+
+class FavoriteStoriesTest(unittest.TestCase):
+
+    def test_favorites_stories_1(self):
+        # Three stories from same fandom.
+        soup = bs("""<div class='z-list favstories'
+                data-category="Pride and Prejudice"  data-storyid="120"</div>
+
+                <div class='z-list favstories'
+                data-category="Pride and Prejudice"  data-storyid="121"</div>
+
+                <div class='z-list favstories'
+                data-category="Pride and Prejudice"  data-storyid="122"</div>
+                """, 'html.parser')
+
+        fav_list, fav_inverted = profile._favorite_stories(soup)
+        self.assertEqual(fav_list, [('120', 'Pride and Prejudice'),
+                                    ('121', 'Pride and Prejudice'),
+                                    ('122', 'Pride and Prejudice')])
+        self.assertEqual(fav_inverted, {'Pride and Prejudice':
+                                        ['120', '121', '122']})
+
+    def test_favorites_stories_2(self):
+        # One story.
+        soup = bs("""<div class='z-list favstories'
+                data-category="Twilight"  data-storyid="500"</div>
+                """, 'html.parser')
+
+        fav_list, fav_inverted = profile._favorite_stories(soup)
+        self.assertEqual(fav_list, [('500', 'Twilight')])
+        self.assertEqual(fav_inverted, {'Twilight': ['500']})
+
+    def test_favorites_stories_3(self):
+        # No favorites
+        soup = bs("""""", 'html.parser')
+
+        fav_list, fav_inverted = profile._favorite_stories(soup)
+        self.assertEqual(fav_list, [])
+        self.assertEqual(fav_inverted, {})
+
+    def test_favorites_stories_4(self):
+        # Mix of fandom.
+        soup = bs("""<div class='z-list favstories'
+                data-category="Twilight"  data-storyid="500"</div>
+
+                <div class='z-list favstories'
+                data-category="Pride and Prejudice"  data-storyid="121"</div>
+                """, 'html.parser')
+
+        fav_list, fav_inverted = profile._favorite_stories(soup)
+        self.assertEqual(fav_list, [('500', 'Twilight'),
+                                    ('121', 'Pride and Prejudice')])
+        self.assertEqual(fav_inverted, {'Twilight': ['500'],
+                                        'Pride and Prejudice': ['121']})

--- a/ffscraper/tests/ffscrapertests/test_fanfic_story.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_story.py
@@ -77,6 +77,30 @@ class CategoryAndFandomTest(unittest.TestCase):
 
         self.assertTrue(True)
 
+class NotEmptyFanficTest(unittest.TestCase):
+
+    def test_empty_fanfic_1(self):
+        # 1. Test when the fanfic is empty (a.k.a. contains the error code)
+        soup = bs(u"""<span class="gui_warning">Story Not Found
+                    <hr noshade="" size="1"/>Unable to locate story.
+                    Code 1.</span>""", 'html.parser')
+        self.assertFalse(story._not_empty_fanfic(soup))
+
+    def test_empty_fanfic_2(self):
+        # 2. Test when the fanfic is not empty.
+        soup = bs('', 'html.parser')
+        self.assertTrue(story._not_empty_fanfic(soup))
+
+    def test_empty_fanfic_3(self):
+        # 3. Test when the fanfic is not empty, but contains something...
+        soup = bs(u"""<div style='margin-bottom: 10px' class='lc-wrapper'
+        id=pre_story_links><span class=lc-left>
+        <a class=xcontrast_txt href='/anime/'>Anime/Manga</a>
+        <span class='xcontrast_txt icon-chevron-right xicon-section-arrow'>
+        </span><a class=xcontrast_txt href="/anime/Attack-on-Titan-%E9%80%B2%E6%92%83%E3%81%AE%E5%B7%A8%E4%BA%BA/">Attack on Titan/進撃の巨人</a>
+        </span></div>""", 'html.parser')
+        self.assertTrue(story._not_empty_fanfic(soup))
+
 class TitleTest(unittest.TestCase):
 
     def test_title_1(self):


### PR DESCRIPTION
### Additions

* `__main__.py` now uses `logging` to track status and errors, only the progress bar is written to stdout.
* `__main__.py` now has a second phase for scraping user profiles for the stories they like; all users who write or review a story are added to a set and profiles are observed. Currently the predicates created during Phase II (i.e. `liked(uid,sid).`) are based on the stories and fandoms encountered during Phase I.
* `ffscraper/author/profile.py` has several functions for getting favorite stories and associated metadata.
* `ffscraper.author.profile._relative_likes` is an early attempt at calculating roughly how much a user likes a particular fandom. As it is currently in this pull request, the function returns a number between `0.0` and `1.0` by dividing the number of stories they like in a fandom over all of the stories they like for all fandoms. This is far from a perfect calculation, taking the number of stories the person has written into account or the sentiment of their reviews may also be useful for improving this result.

### Bugfixes

* Resolved issue #3 which was caused by unexpected characters (notably commas) occasionally showing up in the number of reviews.