### PR TITLE
Favorite Authors and utils imports

### DIFF
--- a/docs/source/ffscraper.rst
+++ b/docs/source/ffscraper.rst
@@ -13,10 +13,10 @@ Subpackages
 Submodules
 ----------
 
-ffscraper\.Utils module
+ffscraper\.utils module
 -----------------------
 
-.. automodule:: ffscraper.Utils
+.. automodule:: ffscraper.utils
     :members:
     :undoc-members:
     :show-inheritance:

--- a/ffscraper/__init__.py
+++ b/ffscraper/__init__.py
@@ -41,3 +41,4 @@ __status__ = 'Prototype'
 from . import fanfic
 from . import author
 from . import nlp
+from . import utils

--- a/ffscraper/__main__.py
+++ b/ffscraper/__main__.py
@@ -31,7 +31,7 @@ else:
 from .fanfic import story
 from .fanfic import review
 from .author import profile
-from . import Utils
+from . import utils
 
 # <Metadata>
 __author__ = 'Alexander L. Hayes (@batflyer)'
@@ -100,13 +100,13 @@ if args.sid:
 
     # Create predicates for BoostSRL.
     predicates = []
-    predicates.append(Utils.PredicateLogicBuilder('author',
+    predicates.append(utils.PredicateLogicBuilder('author',
                                                   current_story['aid'],
                                                   current_story['sid']))
-    predicates.append(Utils.PredicateLogicBuilder('rating',
+    predicates.append(utils.PredicateLogicBuilder('rating',
                                                   current_story['sid'],
                                                   current_story['rating']))
-    predicates.append(Utils.PredicateLogicBuilder('genre',
+    predicates.append(utils.PredicateLogicBuilder('genre',
                                                   current_story['sid'],
                                                   current_story['genre']))
     for p in predicates:
@@ -116,7 +116,7 @@ elif args.file:
     # Import the sids from the file and scrape each of them.
 
     # Initialize the sids as a stack
-    sids = Utils.ImportStoryIDs(args.file)
+    sids = utils.ImportStoryIDs(args.file)
 
     # Initialize the number_of_sids to avoid recalculation and a counter from 0
     number_of_sids = len(sids)
@@ -139,7 +139,7 @@ elif args.file:
         sid = sids.pop()
 
         # Helpful progress bar
-        Utils.progress(counter, number_of_sids,
+        utils.progress(counter, number_of_sids,
                        status='Scraping: {0}...'.format(sid))
 
         # Try scraping the story. If it fails, log and move on.
@@ -167,13 +167,13 @@ elif args.file:
                                    'story' + current_story['sid']))
 
         # Create predicates for BoostSRL.
-        predicates.append(Utils.PredicateLogicBuilder('author',
+        predicates.append(utils.PredicateLogicBuilder('author',
                                                       current_story['aid'],
                                                       current_story['sid']))
-        predicates.append(Utils.PredicateLogicBuilder('rating',
+        predicates.append(utils.PredicateLogicBuilder('rating',
                                                       current_story['sid'],
                                                       current_story['rating']))
-        predicates.append(Utils.PredicateLogicBuilder('genre',
+        predicates.append(utils.PredicateLogicBuilder('genre',
                                                       current_story['sid'],
                                                       current_story['genre']))
 
@@ -185,7 +185,7 @@ elif args.file:
             # Create associated predicates and Cytoscape schemas.
             for reviewer in current_story['Reviewers']:
                 predicates.append(
-                    Utils.PredicateLogicBuilder('reviewed',
+                    utils.PredicateLogicBuilder('reviewed',
                                                 reviewer,
                                                 current_story['sid'])
                     )
@@ -222,7 +222,7 @@ elif args.file:
         uid = people.pop()
 
         # Helpful progress bar
-        Utils.progress(counter, number_of_uids,
+        utils.progress(counter, number_of_uids,
                        status='Scraping: {0}...'.format(uid))
 
         # Try scraping the profile, log if/where the scraper throws errors.
@@ -251,7 +251,7 @@ elif args.file:
                 for sid in inverted_favs[fandom]:
                     if sid in stories:
                         predicates.append(
-                            Utils.PredicateLogicBuilder('liked', uid, sid))
+                            utils.PredicateLogicBuilder('liked', uid, sid))
                         schema.append(
                             schemaString('user' + uid, 'liked', 'story' + sid))
 

--- a/ffscraper/author/beta.py
+++ b/ffscraper/author/beta.py
@@ -15,9 +15,9 @@
 
 from __future__ import print_function
 
-from bs4 import BeautifulSoup as bs
+from ..utils import soupify
 
-import requests
+from bs4 import BeautifulSoup as bs
 import time
 
 def scraper(uid, rate_limit=3):
@@ -65,11 +65,4 @@ def scraper(uid, rate_limit=3):
     time.sleep(rate_limit)
 
     # Make a request to the site, make a BeautifulSoup instance for the html
-    r = requests.get('https://www.fanfiction.net/beta/' + uid)
-    html = r.text
-    soup = bs(html, 'html.parser')
-
-if __name__ == '__main__':
-    # This behavior is for testing, will likely be deprecated or changed later.
-
-    exit(0)
+    soup = soupify('https://www.fanfiction.net/beta/' + uid)

--- a/ffscraper/author/profile.py
+++ b/ffscraper/author/profile.py
@@ -13,12 +13,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+"""
++----------------------+---------------------------------------------------+
+|      **Name**        |                  **Description**                  |
++----------------------+---------------------------------------------------+
+|      profile.py      | Module for scraping a user profile FanFiction.Net |
++----------------------+---------------------------------------------------+
+"""
+
 from __future__ import print_function
 from __future__ import division
 
-from bs4 import BeautifulSoup as bs
+from ..utils import soupify
 
-import requests
+from bs4 import BeautifulSoup as bs
 import time
 
 def _favorite_stories(soup):
@@ -187,20 +195,37 @@ def scraper(uid, rate_limit=3):
     :param rate_limit: Number of seconds to wait at the start of function call
                        in order to enforce scraper niceness.
     :type rate_limit: int.
-    :returns: Currently returns nothing.
+    :returns: Returns a dictionary containing favorite stories, favorite
+              authors.
+    :rtype: dict.
 
-    >>> from ffscraper.author import profile
-    >>> profile123 = profile.scraper('123')
+    .. code-block:: python
+
+                    # File: example.py
+                    import ffscraper as ffs
+
+                    # Scrape the profile of user 123 (details changed)
+                    profile = ffs.author.profile.scraper('123')
+
+                    # Show the key, value pairs for each item in the profile.
+                    for key in profile:
+                        print(key, '-', profile[key])
+
+    .. code-block:: bash
+
+                    $ python example.py
+                    uid - 123
+                    favorite_authors - ['134', '136', '138']
+                    favorite_stories - (['111', 'Hobbit'], {'Hobbit': ['111']})
     """
 
     # Rate Limit
     time.sleep(rate_limit)
 
     # Make a request to the site, make a BeautifulSoup instance for the html
-    r = requests.get('https://www.fanfiction.net/u/' + uid)
-    html = r.text
-    soup = bs(html, 'html.parser')
-
-    #soup.find_all('div', {'class': 'z-list favstories'})
-    #Returns a tuple of (favorite_stories, inverted_favorites)
-    return _favorite_stories(soup)
+    soup = soupify('https://www.fanfiction.net/u/' + uid)
+    return {
+                'uid': uid,
+                'favorite_authors': _favorite_authors(soup),
+                'favorite_stories': _favorite_stories(soup)
+            }

--- a/ffscraper/author/profile.py
+++ b/ffscraper/author/profile.py
@@ -27,11 +27,16 @@ def _favorite_stories(soup):
 
     Find the favorite stories and return them as a list.
 
+    .. note:: Currently crossover fandoms are not split or taken into account
+              closely. It may be useful to see how the crossover fandoms
+              correlate with other stories that the user likes.
+
     :param soup: Soup containing a page from FanFiction.Net
     :type soup: bs4.BeautifulSoup class
 
-    :returns: story-ids liked by the user.
-    :rtype: list
+    :returns: A list of story-ids liked by the user, and a dictionary mapping
+              a fandom to all of the stories that are part of that fandom.
+    :rtype: tuple
     """
 
     # "Favorite Stories" are stored in a z-list favstories.
@@ -53,6 +58,46 @@ def _favorite_stories(soup):
             favorites_inverted[fandom] = [storyid]
 
     return favs, favorites_inverted
+
+def _favorite_authors(soup):
+    """
+    .. versionadded:: 0.3.0
+
+    Find the favorite authors for a user and return them as a list.
+
+    :param soup: Soup containing a page from FanFiction.Net
+    :type soup: bs4.BeautifulSoup class
+
+    :returns: A list of user-ids corresponding to the authors liked by a user.
+    :rtype: list
+
+    Example:
+
+    .. code-block:: python
+
+                    import ffscraper as ffs
+
+                    # Get an example user (details are changed here)
+                    soup = ffs.utils.soupify('https://www.fanfiction.net/u/123')
+
+                    # Get their favorite authors via this function.
+                    fav_authors = ffs.author.profile._favorite_authors(soup)
+
+                    # We'll print to see the results
+                    print(fav_authors)
+
+    .. code-block:: bash
+
+                    ['124', '125', '126']
+    """
+
+    # Favorite Authors for a user is stored under a div with id='fa'
+    authors_table = soup.find('div', {'id': 'fa'})
+    if authors_table:
+        author_links = authors_table.find_all('a')
+        return [a['href'].split('/')[2] for a in author_links]
+    else:
+        return []
 
 def _metadata_storyid(soup_tag):
     """

--- a/ffscraper/fanfic/review.py
+++ b/ffscraper/fanfic/review.py
@@ -26,6 +26,8 @@ from __future__ import division
 
 from bs4 import BeautifulSoup as bs
 
+from ..utils import soupify
+
 import requests
 import time
 
@@ -70,9 +72,8 @@ def ReviewIDScraper(storyid, reviews_num, rate_limit=3):
         # Rate limit
         time.sleep(rate_limit)
 
-        r = requests.get('https://www.fanfiction.net/r/' + storyid + '/0/' + str(p+1) + '/')
-        html = r.text
-        soup = bs(html, 'html.parser')
+        soup = soupify('https://www.fanfiction.net/r/' + storyid +
+                       '/0/' + str(p+1) + '/')
 
         # Get the tbody, which is where the review table is stored
         t = soup.find('tbody')
@@ -128,9 +129,8 @@ def ReviewScraper(storyid, reviews_num, rate_limit=3):
         # Rate limit
         time.sleep(rate_limit)
 
-        r = requests.get('https://www.fanfiction.net/r/' + storyid + '/0/' + str(p+1) + '/')
-        html = r.text
-        soup = bs(html, 'html.parser')
+        soup = soupify('https://www.fanfiction.net/r/' + storyid +
+                       '/0/' + str(p+1) + '/')
 
         # Get the tbody, which is where the review table is stored
         t = soup.find('tbody')
@@ -144,18 +144,3 @@ def ReviewScraper(storyid, reviews_num, rate_limit=3):
                 if '/u/' in str(link):
                     # This is a way to get the user id.
                     print(str(link).split('"')[1].split('/')[2])
-
-            '''
-            print(review.text)
-            #exit()
-            time.sleep(0.5)
-            '''
-
-        #exit()
-
-        #print(p+1)
-
-if __name__ == '__main__':
-
-    raise(Exception('No main class in story.py'))
-    exit(1)

--- a/ffscraper/fanfic/story.py
+++ b/ffscraper/fanfic/story.py
@@ -24,10 +24,10 @@
 from __future__ import print_function
 from __future__ import division
 
+from ..utils import soupify
 from . import review
 
 from bs4 import BeautifulSoup as bs
-import requests
 import time
 
 def _category_and_fandom(soup):
@@ -179,9 +179,7 @@ def scraper(storyid, rate_limit=3):
     time.sleep(rate_limit)
 
     # Make a request to the site, create a BeautifulSoup instance for the html
-    r = requests.get('https://www.fanfiction.net/s/' + storyid)
-    html = r.text
-    soup = bs(html, 'html.parser')
+    soup = soupify('https://www.fanfiction.net/s/' + storyid)
 
     # Check in case the fanfic does not exist
     if not _not_empty_fanfic(soup):

--- a/ffscraper/tests/ffscrapertests/test_author_profile.py
+++ b/ffscraper/tests/ffscrapertests/test_author_profile.py
@@ -23,6 +23,82 @@ import unittest
 sys.path.append('./')
 from ffscraper.author import profile
 
+class FavoriteAuthorsTest(unittest.TestCase):
+
+    # ffscraper.fanfic.author._favorite_authors
+
+    def test_favorite_authors_1(self):
+
+        soup = bs("""<div id='fa' class='tab-pane '>
+                    <table width=100%><tr>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/123/usera'>usera</a></dl>
+                    <dl><a href='/u/124/userb'>userb</a></dl>
+                    <dl><a href='/u/125/userc'>userc</a></dl>
+                    </TD>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/126/userd'>userd</a></dl>
+            	    <dl><a href='/u/127/usere'>usere</a></dl>
+                    </TD>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/128/userf'>userf</a></dl>
+            	    <dl><a href='/u/129/userg'>userg</a></dl>
+                    </TD>
+                    </tr></table></div>""", 'html.parser')
+
+        expected = ['123', '124', '125', '126', '127', '128', '129']
+        reality = profile._favorite_authors(soup)
+        self.assertEqual(expected, reality)
+
+    def test_favorite_authors_2(self):
+
+        soup = bs("""<div id='fa' class='tab-pane '>
+                    <table width=100%><tr>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/1/usera'>usera</a></dl>
+                    </TD>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/2/userd'>userd</a></dl>
+                    </TD>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/3/userf'>userf</a></dl>
+                    </TD>
+                    </tr></table></div>""", 'html.parser')
+
+        expected = ['1', '2', '3']
+        reality = profile._favorite_authors(soup)
+        self.assertEqual(expected, reality)
+
+    def test_favorite_authors_3(self):
+
+        soup = bs("""<div id='fa' class='tab-pane '>
+                    <table width=100%><tr>
+                    <TD VALIGN=TOP style='line-height:150%'>
+            	    <dl><a href='/u/1/usera'>usera</a></dl>
+                    </TD></tr></table></div>""", 'html.parser')
+
+        expected = ['1']
+        reality = profile._favorite_authors(soup)
+        self.assertEqual(expected, reality)
+
+    def test_favorite_authors_4(self):
+
+        soup = bs("""""", 'html.parser')
+
+        expected = []
+        reality = profile._favorite_authors(soup)
+        self.assertEqual(expected, reality)
+
+    def test_favorite_authors_5(self):
+
+        soup = bs("""<div id='fa' class='tab-pane '>
+                    <table width=100%><tr>
+                    </tr></table></div>""", 'html.parser')
+
+        expected = []
+        reality = profile._favorite_authors(soup)
+        self.assertEqual(expected, reality)
+
 class FavoriteStoriesTest(unittest.TestCase):
 
     # ffscraper.fanfic.author._favorite_stories

--- a/ffscraper/tests/ffscrapertests/test_utils.py
+++ b/ffscraper/tests/ffscrapertests/test_utils.py
@@ -1,0 +1,79 @@
+
+# -*- coding: utf-8 -*-
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import sys
+import unittest
+
+sys.path.append('./')
+
+from ffscraper import utils
+
+class PredicateLogicBuilderTest(unittest.TestCase):
+
+    def test_PredicateLogicBuilder_1(self):
+
+        expectation = 'liked("123","1335").'
+        reality = utils.PredicateLogicBuilder('liked', '123', '1335')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_2(self):
+
+        expectation = 'author("a","b").'
+        reality = utils.PredicateLogicBuilder('author', 'a', 'b')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_3(self):
+
+        expectation = 'author("a_b","b_c").'
+        reality = utils.PredicateLogicBuilder('author', 'a_b', 'b_c')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_4(self):
+
+        expectation = 'author("ab","bc").'
+        reality = utils.PredicateLogicBuilder('author', 'a  b', 'b  c')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_5(self):
+
+        expectation = 'author("a_b","b_c").'
+        reality = utils.PredicateLogicBuilder('author', 'a _ b', 'b _ c')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_6(self):
+
+        expectation = ' author ("a","b").'
+        reality = utils.PredicateLogicBuilder(' author ', 'a', 'b')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_7(self):
+
+        expectation = 'words("38,183").'
+        reality = utils.PredicateLogicBuilder('words', '38,183', '')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_8(self):
+
+        expectation = 'words("11aabb").'
+        reality = utils.PredicateLogicBuilder('words', ' 11 aa bb ', '')
+        self.assertEqual(expectation, reality)
+
+    def test_PredicateLogicBuilder_9(self):
+
+        expectation = ' words ("88").'
+        reality = utils.PredicateLogicBuilder(' words ', '    88   ', '')
+        self.assertEqual(expectation, reality)

--- a/ffscraper/utils.py
+++ b/ffscraper/utils.py
@@ -37,10 +37,22 @@ def ImportStoryIDs(path_to_file):
 
     Example:
 
-    >>> from ffscraper.Utils import ImportStoryIDs
-    >>> sids = ffs.Utils.ImportStoryIDs('data/Coraline/sids.txt')
-    >>> print(sids)
-    ['123', '344']
+    .. code-block:: python
+
+                    # File: example.py
+                    import ffscraper as ffs
+
+                    # Story-ids in this example are stored in a text file.
+                    sids = ffs.utils.ImportStoryIDs('data/Coraline/sids.txt')
+                    print(sids)
+
+    .. code-block:: bash
+
+                    $ cat data/Coraline/sids.txt
+                    123
+                    344
+                    $ python example.py
+                    ['123', '344']
 
     .. warning::
        This function was designed and tested with Unix-style paths and
@@ -71,7 +83,7 @@ def PredicateLogicBuilder(type, id, value):
 
     Example:
 
-    >>> from ffscraper.Utils import PredicateLogicBuilder
+    >>> from ffscraper.utils import PredicateLogicBuilder
     >>> f = PredicateLogicBuilder('author', '123', '456')
     >>> print(f)
     author("123","456").
@@ -129,7 +141,7 @@ def progress(count, total, status=''):
 
     Example:
 
-    >>> from ffscraper.Utils import progress
+    >>> from ffscraper.utils import progress
     >>> from time import sleep
     >>> for i in range(1,10):
     ...     sleep(1)

--- a/ffscraper/utils.py
+++ b/ffscraper/utils.py
@@ -204,8 +204,3 @@ def soupify(url):
 
     html = requests.get(url).text
     return bs(html, 'html.parser')
-
-if __name__ == '__main__':
-
-    raise(Exception('No main class in Utils.py'))
-    exit(1)

--- a/ffscraper/utils.py
+++ b/ffscraper/utils.py
@@ -176,6 +176,15 @@ def soupify(url):
 
     :param url: A url to a web address.
     :type url: str.
+
+    :returns: Beautiful Soup html parser for the text at the url.
+    :rtype: bs4.BeautifulSoup class
+
+    .. code-block:: python
+
+                    import ffscraper as ffs
+
+                    soup = ffs.utils.soupify('https://www.fanfiction.net/u/123')
     """
 
     from bs4 import BeautifulSoup as bs

--- a/ffscraper/utils.py
+++ b/ffscraper/utils.py
@@ -168,6 +168,22 @@ def progress(count, total, status=''):
     sys.stdout.write('[%s] %s%s ...%s\r' % (bar, percents, '%', status))
     sys.stdout.flush()
 
+def soupify(url):
+    """
+    .. versionadded:: 0.3.0
+
+    Helper function for returning the soup from a url.
+
+    :param url: A url to a web address.
+    :type url: str.
+    """
+
+    from bs4 import BeautifulSoup as bs
+    import requests
+
+    html = requests.get(url).text
+    return bs(html, 'html.parser')
+
 if __name__ == '__main__':
 
     raise(Exception('No main class in Utils.py'))


### PR DESCRIPTION
### Major Changes

* Renamed `Utils.py` -> `utils.py`
* Test cases for `utils.PredicateLogicBuilder`
* Adjusted the Sphinx source files under `docs/source` to account for renamed utils.
* `__main__.py` accounts for a user's favorite authors, generating predicates and a Cytoscape schema for the relations if the favorite authors are within the set of authors observed for the current session.
* `ffscraper.author.profile.scraper` now returns a dictionary containing information on a user's profile.

### Comments

Something similar to the dictionary return for`ffscraper.author.profile.scraper` will likely be a default in other modules going forward. Returning a dictionary is easy to update over time (just add more keys) and hopefully will help avoid potential backwards-compatability issues in the future.