### PR TITLE
Reworked how reviews were scraped

### DIFF
--- a/ffscraper/fanfic/review.py
+++ b/ffscraper/fanfic/review.py
@@ -33,36 +33,13 @@ import time
 
 def ReviewIDScraper(storyid, reviews_num, rate_limit=3):
     """
-    Scrapes the reviews for a certain story, returning the user ids.
+    .. deprecated:: 0.3.0
 
-    .. warning::
-       This is most likely a short-term hack for this specific function.
-       As ``review.py`` is finalized this will likely be absorbed into the
-       ReviewScraper function or reimagined as a function in a class.
+       Use :func:`scraper` instead.
 
-    :param storyid: Story-id number for a story on FanFiction.Net.
-    :type storyid: str.
-    :param reviews_num: Number of reviews according to the metadata.
-    :type reviews_num: int.
-    :param rate_limit: Number of seconds to wait at the start of function call
-                    in order to enforce scraper niceness.
-    :type rate_limit: int.
-    :returns: A list of user-ids with duplicates removed.
-    :rtype: list of strings.
-
-    Example (*the output presented here has been altered*):
-
-        In this example, the story with ID '1812' was found to have 13 reviews.
-        Of those 13 reviews, four of them were associated with a person. This
-        means that some people may have reviews the story multiple times, or
-        some people reviewed the story anonymously.
-
-    >>> from ffscraper.fanfic.review import ReviewIDScraper
-    >>> reviews_for_1812 = ReviewIDScraper('1812', 13)
-    >>> print(reviews_for_1812)
-    ['18381', '18325', '9312', '1832']
     """
-
+    pass
+    """
     number_of_pages = (reviews_num // 15) + 1
 
     user_id_list = []
@@ -89,60 +66,7 @@ def ReviewIDScraper(storyid, reviews_num, rate_limit=3):
                     user_id_list.append(str(link).split('"')[1].split('/')[2])
 
     return list(set(user_id_list))
-
-def ReviewScraper(storyid, reviews_num, rate_limit=3):
     """
-    Scrapes the reviews for a certain story.
-
-    :param storyid: Story-id number for a story on FanFiction.Net.
-    :type storyid: str.
-    :param reviews_num: Number of reviews according to the metadata.
-    :type reviews_num: int.
-    :param rate_limit: Number of seconds to wait at the start of function call
-                    in order to enforce scraper niceness.
-    :type rate_limit: int.
-    :returns: A list of user-ids with duplicates removed.
-    :rtype: list of strings.
-
-    Discussion:
-        * Reviews on FanFiction.Net may either be anonymous or tied to the user
-          who left the review.
-        * Reviews for a story are located at address:
-          https://www.fanfiction.net/r/[sid]/0/1/
-        * /0/ represents all reviews for a story, /1/ is a page, and there are
-          up to 15 reviews per page.
-        * Incrementing the 0 gives the reviews for a particular chapter.
-
-    Page Layout:
-        * Reviews are stored in an html table of up to 15 elements.
-        * A review may be thought of as a 4-tuple:
-            (userid, chapter_reviewed, date, review_text)
-    """
-
-    # There may be up to 15 reviews on a single page, therefore the number of
-    # pages the reviews  are stored on is equal to the following:
-    number_of_pages = (reviews_num // 15) + 1
-
-    for p in range(number_of_pages):
-
-        # Rate limit
-        time.sleep(rate_limit)
-
-        soup = soupify('https://www.fanfiction.net/r/' + storyid +
-                       '/0/' + str(p+1) + '/')
-
-        # Get the tbody, which is where the review table is stored
-        t = soup.find('tbody')
-
-        # Loop over the table entries (td)
-        for review in t.find_all('td'):
-
-            # Reviews link to the profile of the user who reviewed it.
-            for link in review.find_all('a', href=True):
-
-                if '/u/' in str(link):
-                    # This is a way to get the user id.
-                    print(str(link).split('"')[1].split('/')[2])
 
 def _review_chapter_and_timestamp(soup_tag):
     """
@@ -233,6 +157,37 @@ def _reviews_in_table(soup):
 def scraper(storyid, reviews_num, rate_limit=3):
     """
     Scrapes the reviews for a certain story.
+
+    :param storyid: Story-id number for a story on FanFiction.Net.
+    :type storyid: str.
+    :param reviews_num: Number of reviews according to the metadata.
+    :type reviews_num: int.
+    :param rate_limit: Number of seconds to wait at the start of function call
+                       in order to enforce scraper niceness.
+    :type rate_limit: int.
+
+    :returns: A list of review tuples, where each tuple corresponds to:
+              (reviewer, chapter, timestamp, review_text).
+    :rtype: list of strings.
+
+    1. reviewer: Who left the review (user-id or 'Guest')
+    2. chapter: Chapter the review was left for.
+    3. timestamp: When the review was left.
+    4. review_text: Content of the review.
+
+    Discussion:
+        * Reviews on FanFiction.Net may either be anonymous or tied to the user
+          who left the review.
+        * Reviews for a story are located at address:
+          https://www.fanfiction.net/r/[sid]/0/1/
+        * /0/ represents all reviews for a story, /1/ is a page, and there are
+          up to 15 reviews per page.
+        * Incrementing the 0 gives the reviews for a particular chapter.
+
+    Page Layout:
+        * Reviews are stored in an html table of up to 15 elements.
+        * A review may be thought of as a 4-tuple:
+            (userid, chapter_reviewed, date, review_text)
     """
 
     # There may be up to 15 reviews on a single page, therefore the number of

--- a/ffscraper/fanfic/story.py
+++ b/ffscraper/fanfic/story.py
@@ -223,10 +223,12 @@ def scraper(storyid, rate_limit=3):
 
         for m in metadata:
             if 'Reviews' in m:
-
                 num_of_reviews = int(m.split()[1].replace(',',''))
-                users = review.ReviewIDScraper(storyid, num_of_reviews, rate_limit=rate_limit)
-                story['Reviewers'] = users
+
+                story['num_reviews'] = num_of_reviews
+
+                #users = review.ReviewIDScraper(storyid, num_of_reviews, rate_limit=rate_limit)
+                #story['Reviewers'] = users
 
         #print(metadata)
 

--- a/ffscraper/tests/ffscrapertests/test_fanfic_review.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_review.py
@@ -1,0 +1,75 @@
+
+#   Copyright (c) 2018 Alexander L. Hayes (@batflyer)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from bs4 import BeautifulSoup as bs
+import sys
+import unittest
+
+# This set of tests is interested in ffscraper.fanfic.review
+sys.path.append('./')
+from ffscraper.fanfic import review
+
+class ReviewsTest(unittest.TestCase):
+
+    # ffscraper.fanfic.review
+
+    def test_reviews_1(self):
+
+        soup = bs("""<tbody><tr  >
+                	<td  style='padding-top:10px;padding-bottom:10px'>
+                    <span style='float:right'>
+                    <a href='https://www.fanfiction.net/' style='color:#333333;
+                    border-bottom:0px;' title='Reply to Review'></span>
+                    <a href='/u/123/persona'>persona</a>
+                    <small style='color:gray'>chapter 10 .
+                    <span data-xutime='11111'>5/3</span>
+                    </small><div style='margin-top:5px'>Most recent.</div>
+                    </td></tr>
+                    <tr  ><td  style='padding-top:10px;padding-bottom:10px'>
+                    <span style='float:right'>
+                    <a href='https://www.fanfiction.net/' style='color:#333333;
+                    border-bottom:0px;' title='Reply to Review'></span>
+                    <a href='/u/123/persona'>persona</a>
+                    <small style='color:gray'>chapter 10 .
+                    <span data-xutime='11110'>5/3</span>
+                    </small><div style='margin-top:5px'>Same person.</div>
+                    </td></tr>
+                    <tr  ><td  style='padding-top:10px;padding-bottom:10px'>
+                    <img class='round36' style='clear:left;float:left;
+                    margin-right:3px;padding:2px;border:1px solid #ccc;
+                    -moz-border-radius:2px;-webkit-border-radius:2px;'
+                    src='/static/images/d_60_90.jpg' width=50 height=50> Guest
+                    <small style='color:gray'>chapter 2 .
+                    <span data-xutime='22222'>5/8/1985</span>
+                    </small><div style='margin-top:5px'>Anonymous third.</div>
+                    </td></tr></tbody>""", 'html.parser')
+
+        reviews = review._reviews_in_table(soup)
+        reality = [review for review in reviews]
+
+        self.assertEqual(reality[0][0], '123')
+        self.assertEqual(reality[0][1], '10')
+        self.assertEqual(reality[0][2], '11111')
+        self.assertEqual(reality[0][3], 'Most recent.')
+
+        self.assertEqual(reality[1][0], '123')
+        self.assertEqual(reality[1][1], '10')
+        self.assertEqual(reality[1][2], '11110')
+        self.assertEqual(reality[1][3], 'Same person.')
+
+        self.assertEqual(reality[2][0], 'Guest')
+        self.assertEqual(reality[2][1], '2')
+        self.assertEqual(reality[2][2], '22222')
+        self.assertEqual(reality[2][3], 'Anonymous third.')

--- a/ffscraper/tests/ffscrapertests/test_fanfic_review.py
+++ b/ffscraper/tests/ffscrapertests/test_fanfic_review.py
@@ -57,7 +57,7 @@ class ReviewsTest(unittest.TestCase):
                     </td></tr></tbody>""", 'html.parser')
 
         reviews = review._reviews_in_table(soup)
-        reality = [review for review in reviews]
+        reality = [r for r in reviews]
 
         self.assertEqual(reality[0][0], '123')
         self.assertEqual(reality[0][1], '10')


### PR DESCRIPTION
### Major Changes

* Deprecated `ffscraper.fanfic.review.ReviewIDScraper`. A deprecation warning is currently listed under it but all other code has been commented out, pending final deletion.
* `ffscraper.fanfic.review` has a `scraper` function now which currently returns a 4-tuple consisting of the reviewer (user-id or 'Guest'), the chapter which was reviewed, the timestamp of the review, and text content.
* `ffscraper.fanfic.story.scraper` no longer scrapes reviews, these should be handled separately.
* `__main__.py` has appropriate changes made to account for this.